### PR TITLE
Add forgotten CSS property

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The following custom properties and mixins are available for styling:
 | Custom property | Description | Default |
 | --- | --- | --- |
 | `--paper-tab-ink` | Ink color | `--paper-yellow-a100` |
+| `--paper-tabs-selection-bar-color` | Bar Color | `--paper-yellow-a100` | 
 | `--paper-tab` | Mixin applied to the tab | `{}` |
 | `--paper-tab-content` | Mixin applied to the tab content | `{}` |
 | `--paper-tab-content-unselected` | Mixin applied to the tab content when the tab is not selected | `{}` |


### PR DESCRIPTION
I added the `--paper-tabs-selection-bar-color` property to the guide
